### PR TITLE
Update Snapcraft.yaml for build.snapcraft.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ docker build -t ddooo/fast .
 
 #### Snap
 
+Run the following commands from the root of this repository.
 ```sh
-cd build/snap/
 snapcraft
 snapcraft push fast_*.snap
 snapcraft release fast <revision> <channel>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,16 +1,17 @@
-name: fast
+name: fast-ryanjyoder
 version: 0.0.4
 summary: Test your internet download speed from terminal.
 description: |
   Minimal zero-dependency utility for testing your internet download speed from terminal.
   Powered by Fast.com - Netflix.
 
+base: core18
 grade: stable
 confinement: strict
 
 parts:
   fast:
-    source: ../../
+    source: .
     plugin: go
     go-importpath: github.com/ddo/fast
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: fast-ryanjyoder
+name: fast
 version: 0.0.4
 summary: Test your internet download speed from terminal.
 description: |


### PR DESCRIPTION
This PR will allow the repo to be built and released on every commit to master using https://build.snapcraft.io/. This service will build for all of the following architectures: s390x, ppc64el, arm64, armhf, amd64, and i386.

After this gets merged, the owner of this snap will need to go to https://build.snapcraft.io/ and add the repository.

Let me know if you have any issues with setting up the builds. I'm looking forward to having this snap on ARM.

Related Issue: https://github.com/ddo/fast/issues/10
