### PR TITLE
Make the output machine readable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+fast
 build/docker/fast
 build/snap/*
 !build/snap/snapcraft.yaml

--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ yay -S fast || paru -S fast
 go get -u github.com/ddo/fast
 ```
 
+## Usage
+To use simply invoke `fast` with no arguments.
+```
+$ ./fast
+ -> 340.37 Mbps
+```
+By default fast will print status messages as it progresses and will display a pleasing spinning bar. It will also find the unit of measure most appropriate for your use case.
+
+If you don't want the extra output and you only want the end result, you can use the `--silent` option. Additionally you can force the output into the desired units with the `-k`, `-m`, or `-g` flags.
+
+| Flag     | Description |
+| -------  | ----------- |
+| --silent | Hides status information and only displays the end result |
+| -k       | Forces output into Kbps |
+| -m       | Forces output into Mbps |
+| -g       | Forces output into Gbps |
+
 ## Build
 
 #### Docker

--- a/fast.go
+++ b/fast.go
@@ -3,12 +3,26 @@ package main
 import (
 	"fmt"
 	"time"
+	"flag"
+	"os"
 
 	"github.com/ddo/go-fast"
 	"github.com/ddo/go-spin"
 )
 
 func main() {
+	var kb, mb, gb bool
+	flag.BoolVar(&kb,"k", false, "Format output in Kbps")
+	flag.BoolVar(&mb,"m", false, "Format output in Mbps")
+	flag.BoolVar(&gb,"g", false, "Format output in Gbps")
+
+	flag.Parse()
+
+	if kb && (mb || gb) || (mb && kb) {
+		fmt.Println("You may have at most one formating switch. Choose either -k, -m, or -g")
+		os.Exit(-1)
+	}
+
 	status := ""
 	spinner := spin.New("")
 
@@ -47,7 +61,7 @@ func main() {
 
 	go func() {
 		for Kbps := range KbpsChan {
-			status = format(Kbps)
+			status = format(Kbps,kb,mb,gb)
 		}
 
 		fmt.Printf("\r%c[2K -> %s\n", 27, status)
@@ -62,20 +76,43 @@ func main() {
 	return
 }
 
-func format(Kbps float64) string {
-	unit := "Kbps"
+func formatGbps(Kbps float64)(string,string,float64) {
+	f := "%.2f %s"
+	unit := "Gbps"
+	value := Kbps/1000000
+	return f,unit,value
+}
+func formatMbps(Kbps float64)(string,string,float64) {
+	f := "%.2f %s"
+	unit := "Mbps"
+	value := Kbps/1000
+	return f,unit,value
+}
+func formatKbps(Kbps float64)(string,string,float64) {
 	f := "%.f %s"
+	unit := "Kbps"
+	value := Kbps
+	return f,unit,value
+}
 
-	if Kbps > 1000000 { // Gbps
-		f = "%.2f %s"
-		unit = "Gbps"
-		Kbps /= 1000000
+func format(Kbps float64,kb bool,mb bool, gb bool) string {
+	var value float64
+	var unit string
+	var f string
 
+	if kb {
+		f,unit,value=formatKbps(Kbps)
+	}else if mb {
+		f,unit,value=formatMbps(Kbps)
+	}else if gb {
+		f,unit,value=formatGbps(Kbps)
+	}else if Kbps > 1000000 { // Gbps
+		f,unit,value=formatGbps(Kbps)
 	} else if Kbps > 1000 { // Mbps
-		f = "%.2f %s"
-		unit = "Mbps"
-		Kbps /= 1000
+		f,unit,value=formatMbps(Kbps)
+	}else{
+		f,unit,value=formatKbps(Kbps)
 	}
 
-	return fmt.Sprintf(f, Kbps, unit)
+	return fmt.Sprintf(f, value, unit)
 }

--- a/fast.go
+++ b/fast.go
@@ -11,10 +11,11 @@ import (
 )
 
 func main() {
-	var kb, mb, gb bool
+	var kb, mb, gb, silent bool
 	flag.BoolVar(&kb,"k", false, "Format output in Kbps")
 	flag.BoolVar(&mb,"m", false, "Format output in Mbps")
 	flag.BoolVar(&gb,"g", false, "Format output in Gbps")
+	flag.BoolVar(&silent,"silent", false, "Surpress all output except for the final result")
 
 	flag.Parse()
 
@@ -28,12 +29,13 @@ func main() {
 
 	// output
 	ticker := time.NewTicker(100 * time.Millisecond)
-
-	go func() {
-		for range ticker.C {
-			fmt.Printf("%c[2K %s  %s\r", 27, spinner.Spin(), status)
-		}
-	}()
+	if !silent {
+		go func() {
+			for range ticker.C {
+				fmt.Printf("%c[2K %s  %s\r", 27, spinner.Spin(), status)
+			}
+		}()
+	}
 	// output
 
 	fastCom := fast.New()
@@ -60,11 +62,22 @@ func main() {
 	KbpsChan := make(chan float64)
 
 	go func() {
+		var value,units string
 		for Kbps := range KbpsChan {
-			status = format(Kbps,kb,mb,gb)
-		}
+			value,units = format(Kbps,kb,mb,gb)
+			// don't print the units of measurement if explicitly asked for
+			if kb || mb || gb {
+				status = fmt.Sprintf("%s",value)
+			}else{
+				status = fmt.Sprintf("%s %s",value,units)
+			}
 
-		fmt.Printf("\r%c[2K -> %s\n", 27, status)
+		}
+		if silent {
+			fmt.Printf("%s\n",status)
+		} else {
+			fmt.Printf("\r%c[2K -> %s\n", 27,status)
+		}
 	}()
 
 	err = fastCom.Measure(urls, KbpsChan)
@@ -78,25 +91,25 @@ func main() {
 }
 
 func formatGbps(Kbps float64)(string,string,float64) {
-	f := "%.2f %s"
+	f := "%.2f"
 	unit := "Gbps"
 	value := Kbps/1000000
 	return f,unit,value
 }
 func formatMbps(Kbps float64)(string,string,float64) {
-	f := "%.2f %s"
+	f := "%.2f"
 	unit := "Mbps"
 	value := Kbps/1000
 	return f,unit,value
 }
 func formatKbps(Kbps float64)(string,string,float64) {
-	f := "%.f %s"
+	f := "%.f"
 	unit := "Kbps"
 	value := Kbps
 	return f,unit,value
 }
 
-func format(Kbps float64,kb bool,mb bool, gb bool) string {
+func format(Kbps float64,kb bool,mb bool, gb bool) (string, string) {
 	var value float64
 	var unit string
 	var f string
@@ -115,5 +128,6 @@ func format(Kbps float64,kb bool,mb bool, gb bool) string {
 		f,unit,value=formatKbps(Kbps)
 	}
 
-	return fmt.Sprintf(f, value, unit)
+	strValue := fmt.Sprintf(f,value)
+	return strValue, unit
 }

--- a/fast.go
+++ b/fast.go
@@ -42,7 +42,7 @@ func main() {
 	err := fastCom.Init()
 	if err != nil {
 		fmt.Println(err)
-		return
+		os.Exit(1)
 	}
 
 	status = "connecting"
@@ -51,7 +51,7 @@ func main() {
 	urls, err := fastCom.GetUrls()
 	if err != nil {
 		fmt.Println(err)
-		return
+		os.Exit(1)
 	}
 
 	status = "loading"
@@ -68,11 +68,12 @@ func main() {
 	}()
 
 	err = fastCom.Measure(urls, KbpsChan)
+	ticker.Stop()
 	if err != nil {
 		fmt.Println(err)
+		os.Exit(1)
 	}
 
-	ticker.Stop()
 	return
 }
 

--- a/fast.go
+++ b/fast.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"fmt"
-	"time"
 	"flag"
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/ddo/go-fast"
 	"github.com/ddo/go-spin"
@@ -12,10 +12,10 @@ import (
 
 func main() {
 	var kb, mb, gb, silent bool
-	flag.BoolVar(&kb,"k", false, "Format output in Kbps")
-	flag.BoolVar(&mb,"m", false, "Format output in Mbps")
-	flag.BoolVar(&gb,"g", false, "Format output in Gbps")
-	flag.BoolVar(&silent,"silent", false, "Surpress all output except for the final result")
+	flag.BoolVar(&kb, "k", false, "Format output in Kbps")
+	flag.BoolVar(&mb, "m", false, "Format output in Mbps")
+	flag.BoolVar(&gb, "g", false, "Format output in Gbps")
+	flag.BoolVar(&silent, "silent", false, "Surpress all output except for the final result")
 
 	flag.Parse()
 
@@ -62,21 +62,21 @@ func main() {
 	KbpsChan := make(chan float64)
 
 	go func() {
-		var value,units string
+		var value, units string
 		for Kbps := range KbpsChan {
-			value,units = format(Kbps,kb,mb,gb)
+			value, units = format(Kbps, kb, mb, gb)
 			// don't print the units of measurement if explicitly asked for
 			if kb || mb || gb {
-				status = fmt.Sprintf("%s",value)
-			}else{
-				status = fmt.Sprintf("%s %s",value,units)
+				status = fmt.Sprintf("%s", value)
+			} else {
+				status = fmt.Sprintf("%s %s", value, units)
 			}
 
 		}
 		if silent {
-			fmt.Printf("%s\n",status)
+			fmt.Printf("%s\n", status)
 		} else {
-			fmt.Printf("\r%c[2K -> %s\n", 27,status)
+			fmt.Printf("\r%c[2K -> %s\n", 27, status)
 		}
 	}()
 
@@ -90,44 +90,44 @@ func main() {
 	return
 }
 
-func formatGbps(Kbps float64)(string,string,float64) {
+func formatGbps(Kbps float64) (string, string, float64) {
 	f := "%.2f"
 	unit := "Gbps"
-	value := Kbps/1000000
-	return f,unit,value
+	value := Kbps / 1000000
+	return f, unit, value
 }
-func formatMbps(Kbps float64)(string,string,float64) {
+func formatMbps(Kbps float64) (string, string, float64) {
 	f := "%.2f"
 	unit := "Mbps"
-	value := Kbps/1000
-	return f,unit,value
+	value := Kbps / 1000
+	return f, unit, value
 }
-func formatKbps(Kbps float64)(string,string,float64) {
+func formatKbps(Kbps float64) (string, string, float64) {
 	f := "%.f"
 	unit := "Kbps"
 	value := Kbps
-	return f,unit,value
+	return f, unit, value
 }
 
-func format(Kbps float64,kb bool,mb bool, gb bool) (string, string) {
+func format(Kbps float64, kb bool, mb bool, gb bool) (string, string) {
 	var value float64
 	var unit string
 	var f string
 
 	if kb {
-		f,unit,value=formatKbps(Kbps)
-	}else if mb {
-		f,unit,value=formatMbps(Kbps)
-	}else if gb {
-		f,unit,value=formatGbps(Kbps)
-	}else if Kbps > 1000000 { // Gbps
-		f,unit,value=formatGbps(Kbps)
+		f, unit, value = formatKbps(Kbps)
+	} else if mb {
+		f, unit, value = formatMbps(Kbps)
+	} else if gb {
+		f, unit, value = formatGbps(Kbps)
+	} else if Kbps > 1000000 { // Gbps
+		f, unit, value = formatGbps(Kbps)
 	} else if Kbps > 1000 { // Mbps
-		f,unit,value=formatMbps(Kbps)
-	}else{
-		f,unit,value=formatKbps(Kbps)
+		f, unit, value = formatMbps(Kbps)
+	} else {
+		f, unit, value = formatKbps(Kbps)
 	}
 
-	strValue := fmt.Sprintf(f,value)
+	strValue := fmt.Sprintf(f, value)
 	return strValue, unit
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/ddo/fast
+
+require (
+	github.com/ddo/go-fast v0.0.0-20180221183904-3a2f747dc782
+	github.com/ddo/go-spin v0.0.0-20160718105357-ab0a40e623c0
+	github.com/ddo/pick-json v0.0.0-20170207095303-c8760e09e0fe
+	github.com/ddo/rq v0.0.0-20180104074423-d8ad0e0faf64
+	golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01
+	gopkg.in/ddo/go-dlog.v2 v2.1.0
+	gopkg.in/ddo/pick.v1 v1.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/ddo/go-fast v0.0.0-20180221183904-3a2f747dc782 h1:eLUvgFAzID11rBj2McGOWobrw0e6tVsKEAk2/zTB35w=
+github.com/ddo/go-fast v0.0.0-20180221183904-3a2f747dc782/go.mod h1:FSWBFAxOhcfYWUc6RaycgBezryVDAD0ECXTc9zxp/Xg=
+github.com/ddo/go-spin v0.0.0-20160718105357-ab0a40e623c0 h1:IXCsXx3/itag1jdJ6Pdk96BRuYRHJvcVxn9zMVutt7I=
+github.com/ddo/go-spin v0.0.0-20160718105357-ab0a40e623c0/go.mod h1:F4meHnXw8Iq/mjLWPtyMXrxm0xtANYOhyCeqBvbjPs8=
+github.com/ddo/pick-json v0.0.0-20170207095303-c8760e09e0fe h1:/8DxbVJzB+Rx2wgJ1VGb3ziwGlI2VB3bWqtoldtalUU=
+github.com/ddo/pick-json v0.0.0-20170207095303-c8760e09e0fe/go.mod h1:vhvQl0uhd1j+zZPJhH0mZ1Moz14khMTXkCkNDXavk1Q=
+github.com/ddo/rq v0.0.0-20180104074423-d8ad0e0faf64 h1:ccuGArPA2AQwyfbpnC2NCWCvqypJFhn6eEvpwYDJPf8=
+github.com/ddo/rq v0.0.0-20180104074423-d8ad0e0faf64/go.mod h1:XIayI7kdKklkc7yyWDBYMJLbK/AO4AchQUxdoSFcn+k=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01 h1:po1f06KS05FvIQQA2pMuOWZAUXiy1KYdIf0ElUU2Hhc=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+gopkg.in/ddo/go-dlog.v2 v2.1.0 h1:SrIltB+SYmJLJZp/5vGKGLUpk2VCfLUM1V3jGs7RSh4=
+gopkg.in/ddo/go-dlog.v2 v2.1.0/go.mod h1:CENm6saSBTtC4/HLiyEnKte/MHgJ/LECoptlS6oHBVI=
+gopkg.in/ddo/pick.v1 v1.2.2 h1:5Ue60YhDOzjwaQp3vwHwyuJ4ufj4DyKIxn95W4G7iZI=
+gopkg.in/ddo/pick.v1 v1.2.2/go.mod h1:AgGJKIMzwG3nzr1OX4nqa2+J27vPZXFgFnEWI3zh8Ow=


### PR DESCRIPTION
I want the run the script as a batch job for monitoring purposes but the current output is difficult to read in a script. I converted the script to be more machine readable by 
* adding a `--silent` switch to suppress status output until the end
* adding `-k`, `-m`, and `-g` switches to force output into kbps, mbps, or gbps respectively.
* Changed return codes when the program fails to be non-zero

This PR includes the go modernization changes written by musl's change request.