### PR TITLE
Update "go get" syntax to "go install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ yay -S fast || paru -S fast
 > golang user can install from the source code
 
 ```sh
-go get -u github.com/ddo/fast
+go install github.com/ddo/fast@latest
 ```
 
 ## Usage


### PR DESCRIPTION
The `go get -u …` command in the current README is no longer supported; this PR updates to the current `go install …` syntax.

Thanks for the useful tool!